### PR TITLE
Upgrade button to paper2.0

### DIFF
--- a/re/Paper_Button.re
+++ b/re/Paper_Button.re
@@ -18,8 +18,6 @@ type props = {
   [@bs.optional]
   raised: bool,
   [@bs.optional]
-  primary: bool,
-  [@bs.optional]
   loading: bool,
   [@bs.optional]
   dark: bool,
@@ -40,7 +38,6 @@ let make =
       ~disabled=?,
       ~compact=?,
       ~raised=?,
-      ~primary=?,
       ~loading=?,
       ~dark=?,
       ~icon=?,
@@ -58,7 +55,6 @@ let make =
         ~disabled?,
         ~compact?,
         ~raised?,
-        ~primary?,
         ~loading?,
         ~dark?,
         ~icon?,

--- a/re/Paper_Button.re
+++ b/re/Paper_Button.re
@@ -26,6 +26,8 @@ type props = {
   [@bs.optional]
   color: string,
   [@bs.optional]
+  accessibilityLabel: string,
+  [@bs.optional]
   style: BsReactNative.Style.t,
   [@bs.optional]
   theme: Paper_ThemeProvider.appTheme,
@@ -42,6 +44,7 @@ let make =
       ~dark=?,
       ~icon=?,
       ~color=?,
+      ~accessibilityLabel=?,
       ~style=?,
       ~theme=?,
       ~onPress,
@@ -59,6 +62,7 @@ let make =
         ~dark?,
         ~icon?,
         ~color?,
+        ~accessibilityLabel?,
         ~style?,
         ~theme?,
         ~onPress,


### PR DESCRIPTION
This PR removes primary prop from Button component's bindings. This prop was removed in paper2.0

Fixes #27 