### PR TITLE
feat: adds list accordion example

### DIFF
--- a/example/src/App.re
+++ b/example/src/App.re
@@ -48,6 +48,8 @@ let make = _children => {
                    <RadioButtonExample navigation />
                  | Config.CheckboxExample => <CheckboxExample navigation />
                  | Config.ButtonExample => <ButtonExample navigation />
+                 | Config.ListAccordionExample =>
+                   <ListAccordionExample navigation />
                  }
              }
         </StackNavigator>

--- a/example/src/Home.re
+++ b/example/src/Home.re
@@ -21,11 +21,12 @@ let examples = [|
   {id: 1, name: "Button Example", route: Config.ButtonExample},
   {id: 2, name: "Checkbox Example", route: Config.CheckboxExample},
   {id: 3, name: "Divider Example", route: Config.DividerExample},
-  {id: 4, name: "RadioButton Example", route: Config.RadioButtonExample},
-  {id: 5, name: "Snackbar Example", route: Config.SnackbarExample},
-  {id: 6, name: "Surface Example", route: Config.SurfaceExample},
-  {id: 7, name: "Switch Example", route: Config.SwitchExample},
-  {id: 8, name: "Typography Example", route: Config.TypographyExample},
+  {id: 4, name: "ListAccordion Example", route: Config.ListAccordionExample},
+  {id: 5, name: "RadioButton Example", route: Config.RadioButtonExample},
+  {id: 6, name: "Snackbar Example", route: Config.SnackbarExample},
+  {id: 7, name: "Surface Example", route: Config.SurfaceExample},
+  {id: 8, name: "Switch Example", route: Config.SwitchExample},
+  {id: 9, name: "Typography Example", route: Config.TypographyExample},
 |];
 
 let keyExtractor = (item, _index) => string_of_int(item.id);

--- a/example/src/ListAccordionExample.re
+++ b/example/src/ListAccordionExample.re
@@ -1,0 +1,114 @@
+open BsReactNative;
+open Paper;
+open Navigation;
+
+module Styles = {
+  open Style;
+
+  let container = style([flex(1.0)]);
+
+  let accordion = style([flexDirection(Row), alignItems(Center)]);
+};
+
+let component = ReasonReact.statelessComponent("ListAccordion Example");
+
+let make = (~navigation: StackNavigator.navigation, _children) => {
+  ...component,
+  render: _self =>
+    <StackNavigator.Screen headerTitle="ListAccordion" navigation>
+      ...{
+           () =>
+             <ScrollView style=Styles.container>
+               <List.Section title="Expandable list item">
+                 <List.Accordion
+                   style=Styles.accordion
+                   left={
+                     List.renderIcon((props: List.iconProps) =>
+                       <List.Icon
+                         icon={
+                           List.renderIcon((iconProps: List.iconProps) =>
+                             <RNIcons.MaterialIcons
+                               name=`_folder
+                               color={iconProps.color}
+                             />
+                           )
+                         }
+                         color={props.color}
+                       />
+                     )
+                   }
+                   title="Expandable list item">
+                   <List.Item title="List item 1" />
+                   <List.Item title="List item 2" />
+                 </List.Accordion>
+               </List.Section>
+               <Divider />
+               <List.Section title="Expandable & multiline list item">
+                 <List.Accordion
+                   title="Expandable list item"
+                   description="Describes the expandable list item">
+                   <List.Item title="List item 1" />
+                   <List.Item title="List item 2" />
+                 </List.Accordion>
+               </List.Section>
+               <Divider />
+               <List.Section title="Expandable list with icons">
+                 <List.Accordion
+                   left={
+                     List.renderIcon((props: List.iconProps) =>
+                       <List.Icon
+                         icon={
+                           List.renderIcon((iconProps: List.iconProps) =>
+                             <RNIcons.MaterialIcons
+                               name=`_star
+                               color={iconProps.color}
+                             />
+                           )
+                         }
+                         color={props.color}
+                       />
+                     )
+                   }
+                   title="Accordion item 1">
+                   <List.Item
+                     left={
+                       List.renderIcon((props: List.iconProps) =>
+                         <List.Icon
+                           icon={
+                             List.renderIcon((iconProps: List.iconProps) =>
+                               <RNIcons.MaterialIcons
+                                 name=`_thumbUp
+                                 color={iconProps.color}
+                               />
+                             )
+                           }
+                           color={props.color}
+                         />
+                       )
+                     }
+                     title="List item 1"
+                   />
+                   <List.Item
+                     left={
+                       List.renderIcon((props: List.iconProps) =>
+                         <List.Icon
+                           icon={
+                             List.renderIcon((iconProps: List.iconProps) =>
+                               <RNIcons.MaterialIcons
+                                 name=`_thumbDown
+                                 color={iconProps.color}
+                               />
+                             )
+                           }
+                           color={props.color}
+                         />
+                       )
+                     }
+                     title="List item 2"
+                   />
+                 </List.Accordion>
+               </List.Section>
+             </ScrollView>
+         }
+    </StackNavigator.Screen>,
+};

--- a/example/src/Navigation.re
+++ b/example/src/Navigation.re
@@ -8,7 +8,8 @@ module Config = {
     | SwitchExample
     | RadioButtonExample
     | CheckboxExample
-    | ButtonExample;
+    | ButtonExample
+    | ListAccordionExample;
 };
 
 include ReboltNavigation.Navigation.CreateNavigation(Config);

--- a/re/Paper_List.re
+++ b/re/Paper_List.re
@@ -1,4 +1,12 @@
-type iconProp = {color: string};
+type jsIconProps = {. "color": string};
+
+type iconProps = {color: string};
+
+type renderIcon = jsIconProps => ReasonReact.reactElement;
+
+let renderIcon =
+    (reRenderIcon: iconProps => ReasonReact.reactElement): renderIcon =>
+  (jsIconProps: jsIconProps) => reRenderIcon({color: jsIconProps##color});
 
 module Icon = {
   [@bs.module "react-native-paper"] [@bs.scope "List"]
@@ -7,7 +15,7 @@ module Icon = {
   [@bs.deriving abstract]
   type props = {
     color: string,
-    icon: ReasonReact.reactElement,
+    icon: renderIcon,
     [@bs.optional]
     style: BsReactNative.Style.t,
   };
@@ -29,7 +37,7 @@ module Accordion = {
     [@bs.optional]
     description: string,
     [@bs.optional]
-    left: iconProp => ReasonReact.reactElement,
+    left: renderIcon,
     [@bs.optional]
     theme: Paper_ThemeProvider.appTheme,
     [@bs.optional]
@@ -54,9 +62,9 @@ module Item = {
     [@bs.optional]
     description: string,
     [@bs.optional]
-    left: iconProp => ReasonReact.reactElement,
+    left: renderIcon,
     [@bs.optional]
-    right: iconProp => ReasonReact.reactElement,
+    right: renderIcon,
     [@bs.optional]
     onPress: BsReactNative.RNEvent.NativeEvent.t => unit,
     [@bs.optional]


### PR DESCRIPTION
Had to refactor List components bindings, cause icon as a reactElement is not supported anymore in paper2.0. 

To be honest, I don't like current solution for rendering icons. Every time i have to create RNIcons element and return it from a render prop function. I would like to have ability to just pass name of the icon to paper component for example List.Icon. It's not that flexible solution but it makes it much easier to work with. What do you think @medson10 ? Can we somehow make the prop accept both function or name?