### PR TITLE
feat: add fab example

### DIFF
--- a/example/src/App.re
+++ b/example/src/App.re
@@ -14,13 +14,14 @@ let theme =
       ~colors=
         themeColors(
           ~primary="#6200EE",
-          ~accent="tomato",
-          ~background="white",
+          ~accent="#03dac4",
+          ~background="#f6f6f6",
           ~surface="white",
+          ~error="#B00020",
           ~text="black",
-          ~disabled="gray",
-          ~placeholder="gray",
-          ~backdrop="black",
+          ~disabled="rgba(0, 0, 0, 0.26)",
+          ~placeholder="rgba(0, 0, 0, 0.54)",
+          ~backdrop="rgba(0, 0, 0, 0.5)",
         ),
       (),
     )
@@ -48,6 +49,7 @@ let make = _children => {
                    <RadioButtonExample navigation />
                  | Config.CheckboxExample => <CheckboxExample navigation />
                  | Config.ButtonExample => <ButtonExample navigation />
+                 | Config.FABExample => <FABExample navigation />
                  }
              }
         </StackNavigator>

--- a/example/src/FABExample.re
+++ b/example/src/FABExample.re
@@ -1,0 +1,114 @@
+open BsReactNative;
+open Navigation;
+open Paper;
+
+module Styles = {
+  open Style;
+
+  let container =
+    style([
+      flex(1.0),
+      padding(Pt(4.)),
+      backgroundColor(String("#eeeeee")),
+    ]);
+
+  let row = style([flex(1.), justifyContent(Center), alignItems(Center)]);
+
+  let fab = style([margin(Pt(8.))]);
+};
+
+type state = {visible: bool};
+
+type action =
+  | ToggleVisible(bool);
+
+let component = ReasonReact.reducerComponent("FAB example");
+
+let make = (~navigation: StackNavigator.navigation, _children) => {
+  ...component,
+  initialState: () => {visible: false},
+  reducer: (action, _state) =>
+    switch (action) {
+    | ToggleVisible(visible) => ReasonReact.Update({visible: visible})
+    },
+  render: self =>
+    <StackNavigator.Screen headerTitle="FAB example" navigation>
+      ...{
+           () =>
+             <View style=Styles.container>
+               <View style=Styles.row>
+                 <FAB
+                   small=true
+                   style=Styles.fab
+                   onPress={_event => ()}
+                   icon={FAB.IconName("add")}
+                 />
+                 <FAB
+                   icon={FAB.IconName("favorite")}
+                   style=Styles.fab
+                   onPress={_event => ()}
+                 />
+                 <FAB
+                   icon={FAB.IconName("done")}
+                   label="Extended FAB"
+                   style=Styles.fab
+                   onPress={_event => ()}
+                 />
+                 <FAB
+                   icon={FAB.IconName("cancel")}
+                   label="Disabled FAB"
+                   style=Styles.fab
+                   onPress={_event => ()}
+                   disabled=true
+                 />
+                 <Portal>
+                   <FAB.Group
+                     open_={self.state.visible}
+                     onStateChange={
+                       _fabState =>
+                         self.send(ToggleVisible(!self.state.visible))
+                     }
+                     icon={
+                       self.state.visible ?
+                         FAB.IconName("today") : FAB.IconName("add")
+                     }
+                     actions=[|
+                       FAB.Group.fabAction(
+                         ~icon=
+                           FAB.IconElement(
+                             FAB.renderIcon((props: FAB.iconProps) =>
+                               <RNIcons.MaterialIcons
+                                 name=`_add
+                                 size={props.size}
+                               />
+                             ),
+                           ),
+                         ~onPress=() => (),
+                         (),
+                       ),
+                       FAB.Group.fabAction(
+                         ~icon=FAB.IconName("star"),
+                         ~label="Star",
+                         ~onPress=() => (),
+                         (),
+                       ),
+                       FAB.Group.fabAction(
+                         ~icon=FAB.IconName("email"),
+                         ~label="Email",
+                         ~onPress=() => (),
+                         (),
+                       ),
+                       FAB.Group.fabAction(
+                         ~icon=FAB.IconName("notifications"),
+                         ~label="Notifications",
+                         ~onPress=() => (),
+                         (),
+                       ),
+                     |]
+                   />
+                 </Portal>
+               </View>
+             </View>
+         }
+    </StackNavigator.Screen>,
+};

--- a/example/src/Home.re
+++ b/example/src/Home.re
@@ -21,11 +21,12 @@ let examples = [|
   {id: 1, name: "Button Example", route: Config.ButtonExample},
   {id: 2, name: "Checkbox Example", route: Config.CheckboxExample},
   {id: 3, name: "Divider Example", route: Config.DividerExample},
-  {id: 4, name: "RadioButton Example", route: Config.RadioButtonExample},
-  {id: 5, name: "Snackbar Example", route: Config.SnackbarExample},
-  {id: 6, name: "Surface Example", route: Config.SurfaceExample},
-  {id: 7, name: "Switch Example", route: Config.SwitchExample},
-  {id: 8, name: "Typography Example", route: Config.TypographyExample},
+  {id: 4, name: "FAB Example", route: Config.FABExample},
+  {id: 5, name: "RadioButton Example", route: Config.RadioButtonExample},
+  {id: 6, name: "Snackbar Example", route: Config.SnackbarExample},
+  {id: 7, name: "Surface Example", route: Config.SurfaceExample},
+  {id: 8, name: "Switch Example", route: Config.SwitchExample},
+  {id: 9, name: "Typography Example", route: Config.TypographyExample},
 |];
 
 let keyExtractor = (item, _index) => string_of_int(item.id);

--- a/example/src/Navigation.re
+++ b/example/src/Navigation.re
@@ -8,7 +8,8 @@ module Config = {
     | SwitchExample
     | RadioButtonExample
     | CheckboxExample
-    | ButtonExample;
+    | ButtonExample
+    | FABExample;
 };
 
 include ReboltNavigation.Navigation.CreateNavigation(Config);

--- a/re/Paper_FAB.re
+++ b/re/Paper_FAB.re
@@ -1,32 +1,95 @@
+type jsIconProps = {
+  .
+  "color": string,
+  "size": float,
+};
+
+type iconProps = {
+  color: string,
+  size: float,
+};
+
+type renderIcon = jsIconProps => ReasonReact.reactElement;
+
+let renderIcon =
+    (reRenderIcon: iconProps => ReasonReact.reactElement): renderIcon =>
+  (jsIconProps: jsIconProps) =>
+    reRenderIcon({color: jsIconProps##color, size: jsIconProps##size});
+
+type iconType =
+  | IconName(string)
+  | IconElement(renderIcon);
+
 [@bs.module "react-native-paper"]
 external reactClass: ReasonReact.reactClass = "FAB";
 
+[@bs.deriving abstract]
+type props = {
+  [@bs.optional]
+  label: string,
+  [@bs.optional]
+  small: bool,
+  [@bs.optional]
+  color: string,
+  [@bs.optional]
+  disabled: bool,
+  [@bs.optional]
+  theme: Paper_ThemeProvider.appTheme,
+  [@bs.optional]
+  style: BsReactNative.Style.t,
+  [@bs.optional]
+  onPress: BsReactNative.RNEvent.NativeEvent.t => unit,
+  [@bs.optional]
+  accessibilityLabel: string,
+  [@bs.optional] [@bs.as "icon"]
+  iconAsString: string,
+  [@bs.optional] [@bs.as "icon"]
+  iconAsRenderFunc: renderIcon,
+};
+
 let make =
     (
-      ~label: option(string)=?,
-      ~accessibilityLabel: option(string)=?,
-      ~disabled: bool=false,
-      ~small: bool=false,
-      ~color: option(string)=?,
-      ~theme: option(Paper_ThemeProvider.appTheme)=?,
-      ~icon: ReasonReact.reactElement,
-      ~style: option(BsReactNative.Style.t)=?,
-      ~onPress: option(BsReactNative.RNEvent.NativeEvent.t => unit)=?,
+      ~label=?,
+      ~accessibilityLabel=?,
+      ~disabled=?,
+      ~small=?,
+      ~color=?,
+      ~theme=?,
+      ~icon,
+      ~style=?,
+      ~onPress=?,
       children,
     ) =>
   ReasonReact.wrapJsForReason(
     ~reactClass,
     ~props=
-      Js.Null_undefined.{
-        "label": label,
-        "accessibilityLabel": accessibilityLabel,
-        "disabled": disabled,
-        "small": small,
-        "color": fromOption(color),
-        "icon": icon,
-        "onPress": fromOption(onPress),
-        "style": fromOption(style),
-        "theme": fromOption(theme),
+      switch (icon) {
+      | IconName(name) =>
+        props(
+          ~color?,
+          ~iconAsString=name,
+          ~style?,
+          ~theme?,
+          ~onPress?,
+          ~accessibilityLabel?,
+          ~label?,
+          ~disabled?,
+          ~small?,
+          (),
+        )
+      | IconElement(renderFunc) =>
+        props(
+          ~color?,
+          ~iconAsRenderFunc=renderFunc,
+          ~style?,
+          ~theme?,
+          ~onPress?,
+          ~accessibilityLabel?,
+          ~label?,
+          ~disabled?,
+          ~small?,
+          (),
+        )
       },
     children,
   );
@@ -36,8 +99,11 @@ module Group = {
   external reactClass: ReasonReact.reactClass = "Group";
 
   [@bs.deriving abstract]
-  type fabAction = {
-    icon: string,
+  type _fabAction = {
+    [@bs.optional] [@bs.as "icon"]
+    iconAsString: string,
+    [@bs.optional] [@bs.as "icon"]
+    iconAsRenderFunc: renderIcon,
     onPress: unit => unit,
     [@bs.optional]
     label: string,
@@ -49,6 +115,39 @@ module Group = {
     style: BsReactNative.Style.t,
   };
 
+  let fabAction =
+      (
+        ~icon,
+        ~onPress,
+        ~label=?,
+        ~accessibilityLabel=?,
+        ~color=?,
+        ~style=?,
+        _unit,
+      ) =>
+    switch (icon) {
+    | IconName(name) =>
+      _fabAction(
+        ~iconAsString=name,
+        ~onPress,
+        ~label?,
+        ~accessibilityLabel?,
+        ~color?,
+        ~style?,
+        (),
+      )
+    | IconElement(renderFunc) =>
+      _fabAction(
+        ~iconAsRenderFunc=renderFunc,
+        ~onPress,
+        ~label?,
+        ~accessibilityLabel?,
+        ~color?,
+        ~style?,
+        (),
+      )
+    };
+
   [@bs.deriving abstract]
   type fabState = {
     [@bs.as "open"]
@@ -57,9 +156,8 @@ module Group = {
 
   [@bs.deriving abstract]
   type props = {
-    icon: ReasonReact.reactElement,
     onStateChange: fabState => unit,
-    actions: array(fabAction),
+    actions: array(_fabAction),
     [@bs.as "open"]
     open_: bool,
     [@bs.optional]
@@ -72,6 +170,10 @@ module Group = {
     onPress: BsReactNative.RNEvent.NativeEvent.t => unit,
     [@bs.optional]
     accessibilityLabel: string,
+    [@bs.optional] [@bs.as "icon"]
+    iconAsString: string,
+    [@bs.optional] [@bs.as "icon"]
+    iconAsRenderFunc: renderIcon,
   };
 
   let make =
@@ -90,18 +192,34 @@ module Group = {
     ReasonReact.wrapJsForReason(
       ~reactClass,
       ~props=
-        props(
-          ~color?,
-          ~open_,
-          ~icon,
-          ~style?,
-          ~theme?,
-          ~onPress?,
-          ~actions,
-          ~onStateChange,
-          ~accessibilityLabel?,
-          (),
-        ),
+        switch (icon) {
+        | IconName(name) =>
+          props(
+            ~color?,
+            ~open_,
+            ~iconAsString=name,
+            ~style?,
+            ~theme?,
+            ~onPress?,
+            ~actions,
+            ~onStateChange,
+            ~accessibilityLabel?,
+            (),
+          )
+        | IconElement(renderFunc) =>
+          props(
+            ~color?,
+            ~open_,
+            ~iconAsRenderFunc=renderFunc,
+            ~style?,
+            ~theme?,
+            ~onPress?,
+            ~actions,
+            ~onStateChange,
+            ~accessibilityLabel?,
+            (),
+          )
+        },
       children,
     );
 };

--- a/re/Paper_ThemeProvider.re
+++ b/re/Paper_ThemeProvider.re
@@ -7,6 +7,7 @@ type themeColors = {
   accent: string,
   background: string,
   surface: string,
+  error: string,
   text: string,
   disabled: string,
   placeholder: string,


### PR DESCRIPTION
Changed icon prop in FAB and FAB.Group components to accept variant = 
```js
| IconName(string)
| IconElement(renderFunction)
```

For now IconName has to accept string as a parameter. We can't use types from `bs-react-native-vector-icons`, because function `nameToJs` is not exposed so `IconName(RNIcons.MaterialIcons.name)` doesn't work. It would be cool if we could expose `nameToJs` in `bs-react-native-vector-icons`, it would allow us to pass variants instead of plain strings to `IconName` variant.