### PR TITLE
fix: Portal.Host binding

### DIFF
--- a/re/Paper_Portal.re
+++ b/re/Paper_Portal.re
@@ -1,12 +1,13 @@
 module Host = {
   [@bs.module "react-native-paper"] [@bs.scope "Portal"]
-  external reactClass: ReasonReact.reactClass = "Host";
+  external reactClass : ReasonReact.reactClass = "Host";
 
-  let make = children => ReasonReact.wrapJsForReason(~reactClass, children);
+  let make = children =>
+    ReasonReact.wrapJsForReason(~reactClass, ~props=Js.Obj.empty(), children);
 };
 
 [@bs.module "react-native-paper"]
-external reactClass: ReasonReact.reactClass = "Portal";
+external reactClass : ReasonReact.reactClass = "Portal";
 
 [@bs.deriving abstract]
 type props = {


### PR DESCRIPTION
Adds missing "empty" `~props` in `ReasonReact.wrapJsForReason` for Portal.Host.

Let me know if there's anything off with the "reformatting" below. Didn't see any rules specified anywhere.