### PR TITLE
Add testID props to Text & TextInput components

### DIFF
--- a/re/Paper_Text.re
+++ b/re/Paper_Text.re
@@ -15,6 +15,7 @@ let make =
       ~onLayout: option(unit => unit)=?,
       ~onLongPress: option(unit => unit)=?,
       ~onPress: option(unit => unit)=?,
+      ~testID: option(string)=?,
       children,
     ) =>
   ReasonReact.wrapJsForReason(
@@ -33,6 +34,7 @@ let make =
         "onPress": fromOption(onPress),
         "theme": fromOption(theme),
         "style": fromOption(style),
+        "testID": fromOption(testID),
       },
     children,
   );

--- a/re/Paper_Text.re
+++ b/re/Paper_Text.re
@@ -15,6 +15,7 @@ let make =
       ~onLayout: option(unit => unit)=?,
       ~onLongPress: option(unit => unit)=?,
       ~onPress: option(unit => unit)=?,
+      ~testID: option(string)=?,
       children,
     ) =>
   ReasonReact.wrapJsForReason(
@@ -32,7 +33,7 @@ let make =
         "onLongPress": fromOption(onLongPress),
         "onPress": fromOption(onPress),
         "theme": fromOption(theme),
-        "style": fromOption(style),
+        "testID": fromOption(testID),
       },
     children,
   );

--- a/re/Paper_TextInput.re
+++ b/re/Paper_TextInput.re
@@ -62,6 +62,7 @@ let make =
       ~onSubmitEditing: option(unit => unit)=?,
       ~onFocus: option(unit => unit)=?,
       ~onBlur: option(unit => unit)=?,
+      ~testID: option(string)=?,
       children,
     ) =>
   ReasonReact.wrapJsForReason(
@@ -128,6 +129,7 @@ let make =
         "onSubmitEditing": fromOption(onSubmitEditing),
         "onFocus": fromOption(onFocus),
         "onBlur": fromOption(onBlur),
+        "testID": fromOption(testID),
       },
     children,
   );


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
The props `testID` should be allowed for this component following the  react native [TextInput](https://facebook.github.io/react-native/docs/textinput#props) & ([Text](https://facebook.github.io/react-native/docs/text#testid)) api.
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Use `testID` props for e2e testing
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change -->
