### PR TITLE
feat:add TextInput props to Searchbar

### DIFF
--- a/re/Paper_Searchbar.re
+++ b/re/Paper_Searchbar.re
@@ -18,6 +18,100 @@ type props = {
   onChangeText: string => unit,
   [@bs.optional]
   onIconPress: BsReactNative.RNEvent.NativeEvent.t => unit,
+  [@bs.optional]
+  allowFontScaling: bool,
+  [@bs.optional]
+  autoCorrect: bool,
+  [@bs.optional]
+  autoFocus: bool,
+  [@bs.optional]
+  autoCapitalize: Paper_TextInput.capitalize,
+  [@bs.optional]
+  autoGrow: bool,
+  [@bs.optional]
+  blurOnSubmit: bool,
+  [@bs.optional]
+  caretHidden: bool,
+  [@bs.optional]
+  contextMenuHidden: bool,
+  [@bs.optional]
+  dataDetectorTypes: string,
+  [@bs.optional]
+  enablesReturnKeyAutomatically: bool,
+  [@bs.optional]
+  error: bool,
+  [@bs.optional]
+  keyboardAppearance: string,
+  [@bs.optional]
+  defaultValue: string,
+  [@bs.optional]
+  disabled: bool,
+  [@bs.optional]
+  disableFullscreenUI: bool,
+  [@bs.optional]
+  editable: bool,
+  [@bs.optional]
+  keyboardType: string,
+  [@bs.optional]
+  inlineImageLeft: string,
+  [@bs.optional]
+  inlineImagePadding: string,
+  [@bs.optional]
+  maxHeight: float,
+  [@bs.optional]
+  maxLength: int,
+  [@bs.optional]
+  label: string,
+  [@bs.optional]
+  placeholderTextColor: string,
+  [@bs.optional]
+  returnKeyType: string,
+  [@bs.optional]
+  returnKeyLabel: string,
+  [@bs.optional]
+  spellCheck: bool,
+  [@bs.optional]
+  textBreakStrategy: string,
+  [@bs.optional]
+  underlineColorAndroid: string,
+  [@bs.optional]
+  clearButtonMode: string,
+  [@bs.optional]
+  clearTextOnFocus: string,
+  [@bs.optional]
+  secureTextEntry: bool,
+  [@bs.optional]
+  selectTextOnFocus: bool,
+  [@bs.optional]
+  selectionColor: string,
+  [@bs.optional]
+  underlineColor: string,
+  [@bs.optional]
+  multiline: bool,
+  [@bs.optional]
+  numberOfLines: int,
+  [@bs.optional]
+  onChange: unit => unit,
+  [@bs.optional]
+  onContentSizeChange: unit => unit,
+  [@bs.optional]
+  onKeyPress: unit => unit,
+  [@bs.optional]
+  onEndEditing: unit => unit,
+  [@bs.optional]
+  onLayout: unit => unit,
+  [@bs.optional]
+  onScroll: unit => unit,
+  [@bs.optional]
+  onSelectionChange: unit => unit,
+  [@bs.optional]
+  onSubmitEditing: unit => unit,
+  [@bs.optional]
+  onFocus: unit => unit,
+  [@bs.optional]
+  onBlur: unit => unit,
+  [@bs.optional]
+  testID: string,
 };
 
 let make =
@@ -29,6 +123,53 @@ let make =
       ~style=?,
       ~onChangeText,
       ~onIconPress=?,
+      ~allowFontScaling=false,
+      ~autoCorrect=false,
+      ~autoFocus=false,
+      ~autoCapitalize=?,
+      ~autoGrow=false,
+      ~blurOnSubmit=false,
+      ~caretHidden=false,
+      ~contextMenuHidden=false,
+      ~dataDetectorTypes=?,
+      ~enablesReturnKeyAutomatically=false,
+      ~error=false,
+      ~keyboardAppearance=?,
+      ~defaultValue=?,
+      ~disabled=false,
+      ~disableFullscreenUI=false,
+      ~editable=true,
+      ~keyboardType=?,
+      ~inlineImageLeft=?,
+      ~inlineImagePadding=?,
+      ~maxHeight=?,
+      ~maxLength=?,
+      ~label=?,
+      ~placeholderTextColor=?,
+      ~returnKeyType=?,
+      ~returnKeyLabel=?,
+      ~spellCheck=false,
+      ~textBreakStrategy=?,
+      ~underlineColorAndroid=?,
+      ~clearButtonMode=?,
+      ~clearTextOnFocus=?,
+      ~secureTextEntry=false,
+      ~selectTextOnFocus=false,
+      ~selectionColor=?,
+      ~underlineColor=?,
+      ~multiline=false,
+      ~numberOfLines=?,
+      ~onChange=?,
+      ~onContentSizeChange=?,
+      ~onKeyPress=?,
+      ~onEndEditing=?,
+      ~onLayout=?,
+      ~onScroll=?,
+      ~onSelectionChange=?,
+      ~onSubmitEditing=?,
+      ~onFocus=?,
+      ~onBlur=?,
+      ~testID=?,
       children,
     ) =>
   ReasonReact.wrapJsForReason(
@@ -44,6 +185,53 @@ let make =
           ~style?,
           ~onChangeText,
           ~onIconPress?,
+          ~allowFontScaling,
+          ~autoCorrect,
+          ~autoFocus,
+          ~autoCapitalize?,
+          ~autoGrow,
+          ~blurOnSubmit,
+          ~caretHidden,
+          ~contextMenuHidden,
+          ~dataDetectorTypes?,
+          ~enablesReturnKeyAutomatically,
+          ~error,
+          ~keyboardAppearance?,
+          ~defaultValue?,
+          ~disabled,
+          ~disableFullscreenUI,
+          ~editable,
+          ~keyboardType?,
+          ~inlineImageLeft?,
+          ~inlineImagePadding?,
+          ~maxHeight?,
+          ~maxLength?,
+          ~label?,
+          ~placeholderTextColor?,
+          ~returnKeyType?,
+          ~returnKeyLabel?,
+          ~spellCheck,
+          ~textBreakStrategy?,
+          ~underlineColorAndroid?,
+          ~clearButtonMode?,
+          ~clearTextOnFocus?,
+          ~secureTextEntry,
+          ~selectTextOnFocus,
+          ~selectionColor?,
+          ~underlineColor?,
+          ~multiline,
+          ~numberOfLines?,
+          ~onChange?,
+          ~onContentSizeChange?,
+          ~onKeyPress?,
+          ~onEndEditing?,
+          ~onLayout?,
+          ~onScroll?,
+          ~onSelectionChange?,
+          ~onSubmitEditing?,
+          ~onFocus?,
+          ~onBlur?,
+          ~testID?,
           (),
         )
       | Some(Icon.Element(renderFunc)) =>
@@ -55,6 +243,53 @@ let make =
           ~style?,
           ~onChangeText,
           ~onIconPress?,
+          ~allowFontScaling,
+          ~autoCorrect,
+          ~autoFocus,
+          ~autoCapitalize?,
+          ~autoGrow,
+          ~blurOnSubmit,
+          ~caretHidden,
+          ~contextMenuHidden,
+          ~dataDetectorTypes?,
+          ~enablesReturnKeyAutomatically,
+          ~error,
+          ~keyboardAppearance?,
+          ~defaultValue?,
+          ~disabled,
+          ~disableFullscreenUI,
+          ~editable,
+          ~keyboardType?,
+          ~inlineImageLeft?,
+          ~inlineImagePadding?,
+          ~maxHeight?,
+          ~maxLength?,
+          ~label?,
+          ~placeholderTextColor?,
+          ~returnKeyType?,
+          ~returnKeyLabel?,
+          ~spellCheck,
+          ~textBreakStrategy?,
+          ~underlineColorAndroid?,
+          ~clearButtonMode?,
+          ~clearTextOnFocus?,
+          ~secureTextEntry,
+          ~selectTextOnFocus,
+          ~selectionColor?,
+          ~underlineColor?,
+          ~multiline,
+          ~numberOfLines?,
+          ~onChange?,
+          ~onContentSizeChange?,
+          ~onKeyPress?,
+          ~onEndEditing?,
+          ~onLayout?,
+          ~onScroll?,
+          ~onSelectionChange?,
+          ~onSubmitEditing?,
+          ~onFocus?,
+          ~onBlur?,
+          ~testID?,
           (),
         )
       | None =>
@@ -65,6 +300,53 @@ let make =
           ~style?,
           ~onChangeText,
           ~onIconPress?,
+          ~allowFontScaling,
+          ~autoCorrect,
+          ~autoFocus,
+          ~autoCapitalize?,
+          ~autoGrow,
+          ~blurOnSubmit,
+          ~caretHidden,
+          ~contextMenuHidden,
+          ~dataDetectorTypes?,
+          ~enablesReturnKeyAutomatically,
+          ~error,
+          ~keyboardAppearance?,
+          ~defaultValue?,
+          ~disabled,
+          ~disableFullscreenUI,
+          ~editable,
+          ~keyboardType?,
+          ~inlineImageLeft?,
+          ~inlineImagePadding?,
+          ~maxHeight?,
+          ~maxLength?,
+          ~label?,
+          ~placeholderTextColor?,
+          ~returnKeyType?,
+          ~returnKeyLabel?,
+          ~spellCheck,
+          ~textBreakStrategy?,
+          ~underlineColorAndroid?,
+          ~clearButtonMode?,
+          ~clearTextOnFocus?,
+          ~secureTextEntry,
+          ~selectTextOnFocus,
+          ~selectionColor?,
+          ~underlineColor?,
+          ~multiline,
+          ~numberOfLines?,
+          ~onChange?,
+          ~onContentSizeChange?,
+          ~onKeyPress?,
+          ~onEndEditing?,
+          ~onLayout?,
+          ~onScroll?,
+          ~onSelectionChange?,
+          ~onSubmitEditing?,
+          ~onFocus?,
+          ~onBlur?,
+          ~testID?,
           (),
         )
       },


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->

<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

The Searchbar component should allow the same props as the TextField component as seen in the [react-native-paper repo](https://github.com/callstack/react-native-paper/blob/master/src/components/Searchbar.js).

Now it's possible to for example use the "onSubmitEditing" when the softkey submit/search is pressed as noted in this react-native-paper issue: ["Having onKeyPress on Searchbar and TextInput Components"](https://github.com/callstack/react-native-paper/issues/712).

### Test plan

<!-- List the steps with which we can test this change -->

Use the Searchbar component with the new props.
